### PR TITLE
Introduce dynamic terms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "App\\Tests\\": "tests/"
+      "App\\Tests\\": "tests/",
+      "App\\Tests\\Unit\\": "tests/Unit"
     }
   },
   "replace": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -46,3 +46,9 @@ services:
     App\Service\GoogleRecaptchaApiServiceInterface: '@App\Service\GoogleRecaptchaApiService'
 
     App\Service\KeycloakRestApiServiceInterface: '@App\Service\KeycloakRestApiService'
+
+    Symfony\Bridge\Twig\Extension\TranslationExtension: '@twig.extension.trans'
+
+    App\Twig\DynamicTermTranslationExtension:
+        tags:
+            - { name: twig.extension, priority: -1024 }

--- a/src/Controller/Admin/DynamicTermsController.php
+++ b/src/Controller/Admin/DynamicTermsController.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\DynamicTerm;
+use App\Form\Admin\DynamicTermModel;
+use App\Form\Admin\DynamicTermType;
+use App\Repository\DynamicTermRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/dynamic-terms", name="dynamic-terms_")
+ *
+ * @IsGranted("ROLE_MARKETING")
+ */
+class DynamicTermsController extends AbstractController
+{
+    /**
+     * @var DynamicTermRepository
+     */
+    private $dynamicTermRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    public function __construct(DynamicTermRepository $dynamicTermRepository, EntityManagerInterface $entityManager)
+    {
+        $this->dynamicTermRepository = $dynamicTermRepository;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @Route("/", name="list", methods={"GET"})
+     */
+    public function list(): Response
+    {
+        return $this->render('admin/dynamic-terms/list.html.twig', [
+            'dynamicTerms' => $this->dynamicTermRepository->findAll(),
+        ]);
+    }
+
+    /**
+     * @Route("/{id}/edit", name="edit", methods={"GET", "POST"})
+     */
+    public function edit(DynamicTerm $dynamicTerm, Request $request): Response
+    {
+        $form = $this
+            ->createForm(DynamicTermType::class, DynamicTermModel::fromEntity($dynamicTerm))
+            ->handleRequest($request)
+        ;
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            /** @var DynamicTermModel $dynamicTermModel */
+            $dynamicTermModel = $form->getData();
+            $dynamicTerm->update($dynamicTermModel->placeholder, $dynamicTermModel->value);
+
+            $this->entityManager->persist($dynamicTerm);
+            $this->entityManager->flush();
+
+            return $this->redirectToRoute('admin_dynamic-terms_list');
+        }
+
+        return $this->render('admin/dynamic-terms/edit.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @Route("/create", name="create", methods={"GET", "POST"})
+     */
+    public function create(Request $request): Response
+    {
+        $dynamicTerm = new DynamicTerm('', '');
+
+        return $this->edit($dynamicTerm, $request);
+    }
+
+    /**
+     * @Route("/{id}/delete", name="delete", methods={"GET"})
+     */
+    public function delete(DynamicTerm $dynamicTerm): Response
+    {
+        $this->entityManager->remove($dynamicTerm);
+        $this->entityManager->flush();
+
+        return $this->redirectToRoute('admin_dynamic-terms_list');
+    }
+}

--- a/src/Entity/DynamicTerm.php
+++ b/src/Entity/DynamicTerm.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\DynamicTermRepository")
+ */
+class DynamicTerm
+{
+    /**
+     * @var UuidInterface|null
+     *
+     * @ORM\Id
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
+     */
+    private $id = null;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(unique=true)
+     */
+    private $placeholder;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column
+     */
+    private $value;
+
+    public function __construct(string $placeholder, string $value)
+    {
+        $this->placeholder = $placeholder;
+        $this->value = $value;
+    }
+
+    public function getId(): ?UuidInterface
+    {
+        return $this->id;
+    }
+
+    public function getPlaceholder(): string
+    {
+        return $this->placeholder;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function update(string $placeholder, string $value): void
+    {
+        $this->placeholder = $placeholder;
+        $this->value = $value;
+    }
+}

--- a/src/Form/Admin/DynamicTermModel.php
+++ b/src/Form/Admin/DynamicTermModel.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Admin;
+
+use App\Entity\DynamicTerm;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class DynamicTermModel
+{
+    /**
+     * @Assert\NotBlank
+     *
+     * @var string
+     */
+    public $placeholder = '';
+
+    /**
+     * @Assert\NotBlank
+     *
+     * @var string
+     */
+    public $value = '';
+
+    public static function fromEntity(DynamicTerm $dynamicTerm): self
+    {
+        $self = new self();
+        $self->placeholder = $dynamicTerm->getPlaceholder();
+        $self->value = $dynamicTerm->getValue();
+
+        return $self;
+    }
+}

--- a/src/Form/Admin/DynamicTermType.php
+++ b/src/Form/Admin/DynamicTermType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DynamicTermType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('placeholder', TextType::class)
+            ->add('value', TextType::class)
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => DynamicTermModel::class,
+        ]);
+    }
+}

--- a/src/Migrations/Version20200515130039.php
+++ b/src/Migrations/Version20200515130039.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200515130039 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE `dynamic_term` (`id` char(36) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT \'(DC2Type:uuid)\',`placeholder` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,`value` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,PRIMARY KEY (`id`),UNIQUE KEY `UNIQ_B470FD698A90ABA9` (`placeholder`)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(),
+            'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE dynamic_term');
+    }
+}

--- a/src/Repository/DynamicTermRepository.php
+++ b/src/Repository/DynamicTermRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\DynamicTerm;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
+
+/**
+ * @method DynamicTerm|null find($id, $lockMode = null, $lockVersion = null)
+ * @method DynamicTerm|null findOneBy(array $criteria, array $orderBy = null)
+ * @method DynamicTerm[]    findAll()
+ * @method DynamicTerm[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class DynamicTermRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, DynamicTerm::class);
+    }
+
+    public function findByPlaceholders(array $placeholder): array
+    {
+        if (empty($placeholder)) {
+            return [];
+        }
+
+        $queryBuilder = $this->createQueryBuilder('dt');
+
+        return $queryBuilder
+            ->andWhere($queryBuilder->expr()->in('dt.placeholder', $placeholder))
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+}

--- a/src/Service/DynamicTermsReplacer.php
+++ b/src/Service/DynamicTermsReplacer.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\DynamicTerm;
+use App\Repository\DynamicTermRepository;
+
+class DynamicTermsReplacer
+{
+    private $dynamicTermRepository;
+
+    public function __construct(DynamicTermRepository $dynamicTermRepository)
+    {
+        $this->dynamicTermRepository = $dynamicTermRepository;
+    }
+
+    public function replaceDynamicTerms(string $message): string
+    {
+        $placeholders = $this->extractPlaceholders($message);
+
+        $dynamicTerms = $this->dynamicTermRepository->findByPlaceholders(array_map(
+            static function (string $placeholder) {
+                return trim($placeholder, '_');
+            },
+            $placeholders
+        ));
+
+        foreach ($dynamicTerms as $dynamicTerm) {
+            /** @var DynamicTerm $dynamicTerm */
+            $message = str_ireplace(
+                sprintf('__%s__', $dynamicTerm->getPlaceholder()),
+                $dynamicTerm->getValue(),
+                $message
+            );
+        }
+
+        return $message;
+    }
+
+    private function extractPlaceholders(string $message): array
+    {
+        preg_match_all('/(?P<placeholder>__[_-a-zA-Z0-9]+__)/', $message, $matches);
+
+        return $matches['placeholder'];
+    }
+}

--- a/src/Twig/DynamicTermTranslationExtension.php
+++ b/src/Twig/DynamicTermTranslationExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Service\DynamicTermsReplacer;
+use Symfony\Bridge\Twig\Extension\TranslationExtension;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class DynamicTermTranslationExtension extends AbstractExtension
+{
+    private $translationExtension;
+    private $dynamicTermsReplacer;
+
+    public function __construct(
+        TranslationExtension $translationExtension,
+        DynamicTermsReplacer $dynamicTermsReplacer
+    ) {
+        $this->translationExtension = $translationExtension;
+        $this->dynamicTermsReplacer = $dynamicTermsReplacer;
+    }
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('trans', [$this, 'trans']),
+        ];
+    }
+
+    public function trans(string $message, array $arguments = [], string $domain = null, string $locale = null, int $count = null): string
+    {
+        return $this->dynamicTermsReplacer->replaceDynamicTerms(
+            $this->translationExtension->trans($message, $arguments, $domain, $locale, $count)
+        );
+    }
+}

--- a/templates/admin/admin_base_layout.html.twig
+++ b/templates/admin/admin_base_layout.html.twig
@@ -44,6 +44,9 @@
                         <a class="nav-link" href="{{ path('admin_mentions_list') }}">Mentions</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" href="{{ path('admin_dynamic-terms_list') }}">Dynamic Terms</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="{{ path('admin_faq_section_list') }}">FAQs</a>
                     </li>
                 {% endif %}

--- a/templates/admin/dynamic-terms/edit.html.twig
+++ b/templates/admin/dynamic-terms/edit.html.twig
@@ -1,0 +1,10 @@
+{% extends 'admin/admin_base_layout.html.twig' %}
+
+{% block container %}
+    {{ form_start(form) }}
+    {{ form_row(form.placeholder) }}
+    {{ form_row(form.value) }}
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="{{ path('admin_dynamic-terms_list') }}" class="btn btn-secondary">Cancel</a>
+    {{ form_end(form) }}
+{% endblock %}

--- a/templates/admin/dynamic-terms/list.html.twig
+++ b/templates/admin/dynamic-terms/list.html.twig
@@ -1,0 +1,33 @@
+{% extends 'admin/admin_base_layout.html.twig' %}
+
+{% block container %}
+    <a href="{{ path('admin_dynamic-terms_create') }}" class="btn btn-success">Create New</a>
+
+    <br/><br/>
+
+    {% if dynamicTerms|length > 0 %}
+        <table class="table">
+            <thead>
+            <tr>
+                <th scope="col">Placeholder</th>
+                <th scope="col">Value</th>
+                <th scope="col" style="width: 15%">Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for dynamicTerm in dynamicTerms %}
+                <tr>
+                    <td>{{ dynamicTerm.placeholder }}</td>
+                    <td>{{ dynamicTerm.value }}</td>
+                    <td>
+                        <a href="{{ path('admin_dynamic-terms_edit', {'id': dynamicTerm.id}) }}" class="btn btn-sm btn-warning">Edit</a>
+                        <a href="{{ path('admin_dynamic-terms_delete', {'id': dynamicTerm.id}) }}" class="btn btn-sm btn-danger">Delete</a>
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <div class="alert alert-warning">Nothing found</div>
+    {% endif %}
+{% endblock %}

--- a/tests/Unit/Service/DynamicTermsReplacerTest.php
+++ b/tests/Unit/Service/DynamicTermsReplacerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\DynamicTerm;
+use App\Repository\DynamicTermRepository;
+use App\Service\DynamicTermsReplacer;
+use PHPUnit\Framework\TestCase;
+
+final class DynamicTermsReplacerTest extends TestCase
+{
+    /**
+     * @dataProvider provideMessages
+     */
+    public function test_replace_placeholders_works_correctly(
+        string $messageWithPlaceholder,
+        string $expectedMessagesWithReplacedPlaceholder,
+        array $dynamicTerms
+    ): void {
+        $dynamicTermsReplacer = new DynamicTermsReplacer(
+            $dynamicTermRepositoryMock = $this->createMock(DynamicTermRepository::class)
+        );
+
+        $dynamicTermRepositoryMock
+            ->method('findByPlaceholders')
+            ->with($this->anything())
+            ->willReturn($dynamicTerms)
+        ;
+
+        $this->assertSame(
+            $expectedMessagesWithReplacedPlaceholder,
+            $dynamicTermsReplacer->replaceDynamicTerms($messageWithPlaceholder)
+        );
+    }
+
+    public function provideMessages(): \Generator
+    {
+        yield [
+            'Personen: __EXPERT_COUNT__ | Partner: __PARTNER__',
+            'Personen: __EXPERT_COUNT__ | Partner: __PARTNER__',
+            [],
+        ];
+        yield [
+            'Personen: __EXPERT_COUNT__',
+            'Personen: 80',
+            [
+                new DynamicTerm('EXPERT_COUNT', '80'),
+            ],
+        ];
+        yield [
+            'Partner: __PARTNER__',
+            'Partner: Partner One, Partner Two',
+            [
+                new DynamicTerm('PARTNER', 'Partner One, Partner Two'),
+            ],
+        ];
+        yield [
+            'Personen: __EXPERT_COUNT__ | Partner: __PARTNER__',
+            'Personen: 80 | Partner: Partner One, Partner Two',
+            [
+                new DynamicTerm('EXPERT_COUNT', '80'),
+                new DynamicTerm('PARTNER', 'Partner One, Partner Two'),
+            ],
+        ];
+        yield [
+            'Personen: __EXPERT_COUNT__ | Partner: __PARTNER__',
+            'Personen: 80 | Partner: __PARTNER__',
+            [
+                new DynamicTerm('EXPERT_COUNT', '80'),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
It's now possible to define dynamic terms in the admin area:

![Screenshot 2020-05-15 at 19 15 08](https://user-images.githubusercontent.com/1880467/82077863-69cb6700-96e0-11ea-991e-e87487c26baf.png)

You can use dynamic terms as placeholders in your translation files:

```
# message.de.yaml
base.nav-experts: 'Unsere __EXPERT_COUNT__ Experten'
```

and translate them with the new `trans_with_dynamic_term` twig filter in your templates like this:

```
<p>{{ 'base.nav-experts'|trans_with_dynamic_term }}</p>
```
